### PR TITLE
feat: add host radius repulsion

### DIFF
--- a/HostCustomData.ini
+++ b/HostCustomData.ini
@@ -9,4 +9,11 @@ ShellCount=3
 PointsPerShell=24
 ShellSpacing=300
 BaseRadius=2000
+ 
+[Avoidance]
+HostRadius=0
+HostBuffer=22
+MinSeparation=18
+SeparationGain=1.1
+UseSensors=true
 ; Sensors must include "[Swarm Sensor]" in the block name

--- a/SatelliteCustomData.ini
+++ b/SatelliteCustomData.ini
@@ -14,4 +14,10 @@ ArrivalTolerance=4.0
 AlignToHost=true
 AlignKp=2.0
 AlignDeadzoneDeg=3
+[Avoidance]
+HostRadius=0
+HostBuffer=22
+MinSeparation=18
+SeparationGain=1.1
+UseSensors=true
 ; Sensors must include "[Swarm Sensor]" in the block name


### PR DESCRIPTION
## Summary
- push satellites away using distance-based repulsion that scales as they approach the host
- add configurable `HostRadius` to define the host's physical size
- update example configuration files with new avoidance settings

## Testing
- `csc Swarm.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd281383c832dbd182996bb2cceef