### PR TITLE
Add kamikaze command for host

### DIFF
--- a/DONTREADME.md
+++ b/DONTREADME.md
@@ -1,0 +1,10 @@
+# DragonSwarm
+
+Terminal arguments:
+
+- `reload` – re-read Custom Data and rediscover blocks
+- `debug on|off` – toggle debug output
+- `index <n>` – set this programmable block's swarm index
+- `boom` – (host) broadcast `CMD|DETONATE|` to all satellites
+- `kamikaze` – (host) broadcast `CMD|KAMIKAZE|` to all satellites
+

--- a/Swarm.cs
+++ b/Swarm.cs
@@ -379,6 +379,10 @@ public void Main(string argument, UpdateType updateSource)
         {
             IGC.SendBroadcastMessage(_cmdTag, "CMD|DETONATE|", TransmissionDistance.TransmissionDistanceMax);
         }
+        else if (argument == "kamikaze" && _role == Role.Host)
+        {
+            IGC.SendBroadcastMessage(_cmdTag, "CMD|KAMIKAZE|", TransmissionDistance.TransmissionDistanceMax);
+        }
     }
 
     double dt = Runtime.TimeSinceLastRun.TotalSeconds;


### PR DESCRIPTION
## Summary
- Allow host to broadcast `CMD|KAMIKAZE|` when terminal argument `kamikaze` is issued
- Document terminal commands including new `kamikaze`

## Testing
- ⚠️ No tests were run per user instructions


------
https://chatgpt.com/codex/tasks/task_e_689fe6ba4490832d94d4fc7d39e1918d