### PR TITLE
Add kamikaze command and warhead handling

### DIFF
--- a/Swarm.cs
+++ b/Swarm.cs
@@ -49,6 +49,7 @@ string _refUp = string.Empty;      // reserved
 
 int _index = -1; // satellite index (global)
 bool _debug = false;
+bool _kamikaze = false;
 
 // cached blocks
 IMyShipController _controller;
@@ -478,6 +479,16 @@ void SatStep()
                         }
                     }
                 }
+                else if (parts.Length > 1 && parts[1] == "KAMIKAZE")
+                {
+                    _kamikaze = true;
+                    for (int i=0; i<_warheads.Count; i++)
+                    {
+                        var w = _warheads[i];
+                        if (w != null)
+                            w.IsArmed = true;
+                    }
+                }
             }
         }
     }
@@ -594,6 +605,16 @@ void ControlStep()
             if (!s.IsWorking || !s.IsActive) continue;
             var info = s.LastDetectedEntity;
             if (info.Type == MyDetectedEntityType.None) continue;
+
+            if (_kamikaze)
+            {
+                for (int j=0; j<_warheads.Count; j++)
+                {
+                    var w = _warheads[j];
+                    if (w != null)
+                        w.Detonate();
+                }
+            }
 
             Vector3D p = info.Position; // world
             Vector3D sep = myPos - p;


### PR DESCRIPTION
## Summary
- handle CMD|KAMIKAZE by arming warheads and setting kamikaze mode
- trigger sensor-based detonation when kamikaze is active
- add _kamikaze flag for satellites

## Testing
- `csc Swarm.cs` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fe6bc4cfc832d8d13fe2a8630bbe2