### PR TITLE
Add kamikaze attack mode to satellite control

### DIFF
--- a/Swarm.cs
+++ b/Swarm.cs
@@ -74,6 +74,7 @@ int _tick = 0;
 int _totalPoints = 0;
 int _shellOfIndex = 0;
 int _pointInShell = 0;
+bool _kamikaze = false;
 
 // host telemetry data
 long _hostId;
@@ -466,16 +467,24 @@ void SatStep()
             if (s != null && msg.Tag == _cmdTag && s.StartsWith("CMD|", System.StringComparison.Ordinal))
             {
                 var parts = s.Split('|');
-                if (parts.Length > 1 && parts[1] == "DETONATE")
+                if (parts.Length > 1)
                 {
-                    for (int i=0; i<_warheads.Count; i++)
+                    if (parts[1] == "DETONATE")
                     {
-                        var w = _warheads[i];
-                        if (w != null)
+                        for (int i=0; i<_warheads.Count; i++)
                         {
-                            w.IsArmed = true;
-                            w.Detonate();
+                            var w = _warheads[i];
+                            if (w != null)
+                            {
+                                w.IsArmed = true;
+                                w.Detonate();
+                            }
                         }
+                        ClearOverrides();
+                    }
+                    else if (parts[1] == "KAMIKAZE")
+                    {
+                        _kamikaze = true;
                     }
                 }
             }
@@ -486,6 +495,7 @@ void SatStep()
     if (_timeSinceTelemetry > 10.0)
     {
         ClearOverrides();
+        _kamikaze = false;
         return;
     }
 
@@ -550,6 +560,75 @@ void ControlStep()
     _shipMass = _controller.CalculateShipMass().PhysicalMass;
     Vector3D myPos = _controller.GetPosition();
     Vector3D vel   = _controller.GetShipVelocities().LinearVelocity;
+
+    if (_kamikaze)
+    {
+        Vector3D toHost = _hostPos - myPos;
+        Vector3D dir = Vector3D.Normalize(toHost);
+        MatrixD grid = Me.CubeGrid.WorldMatrix;
+        Vector3D localDir = Vector3D.TransformNormal(dir, MatrixD.Transpose(grid));
+
+        if (localDir.X >= 0)
+        {
+            for (int i=0; i<_axisX.Pos.Count; i++) _axisX.Pos[i].ThrustOverridePercentage = 1f;
+            for (int i=0; i<_axisX.Neg.Count; i++) _axisX.Neg[i].ThrustOverridePercentage = 0f;
+        }
+        else
+        {
+            for (int i=0; i<_axisX.Neg.Count; i++) _axisX.Neg[i].ThrustOverridePercentage = 1f;
+            for (int i=0; i<_axisX.Pos.Count; i++) _axisX.Pos[i].ThrustOverridePercentage = 0f;
+        }
+
+        if (localDir.Y >= 0)
+        {
+            for (int i=0; i<_axisY.Pos.Count; i++) _axisY.Pos[i].ThrustOverridePercentage = 1f;
+            for (int i=0; i<_axisY.Neg.Count; i++) _axisY.Neg[i].ThrustOverridePercentage = 0f;
+        }
+        else
+        {
+            for (int i=0; i<_axisY.Neg.Count; i++) _axisY.Neg[i].ThrustOverridePercentage = 1f;
+            for (int i=0; i<_axisY.Pos.Count; i++) _axisY.Pos[i].ThrustOverridePercentage = 0f;
+        }
+
+        if (localDir.Z >= 0)
+        {
+            for (int i=0; i<_axisZ.Pos.Count; i++) _axisZ.Pos[i].ThrustOverridePercentage = 1f;
+            for (int i=0; i<_axisZ.Neg.Count; i++) _axisZ.Neg[i].ThrustOverridePercentage = 0f;
+        }
+        else
+        {
+            for (int i=0; i<_axisZ.Neg.Count; i++) _axisZ.Neg[i].ThrustOverridePercentage = 1f;
+            for (int i=0; i<_axisZ.Pos.Count; i++) _axisZ.Pos[i].ThrustOverridePercentage = 0f;
+        }
+
+        ApplyGyros(toHost);
+
+        bool det = false;
+        if (_useSensors && _sensors.Count > 0)
+        {
+            for (int i=0; i<_sensors.Count; i++)
+            {
+                var s = _sensors[i];
+                if (s.IsWorking && s.IsActive) { det = true; break; }
+            }
+        }
+        if (!det && toHost.LengthSquared() < 25.0) det = true;
+        if (det)
+        {
+            for (int i=0; i<_warheads.Count; i++)
+            {
+                var w = _warheads[i];
+                if (w != null)
+                {
+                    w.IsArmed = true;
+                    w.Detonate();
+                }
+            }
+            ClearOverrides();
+            _kamikaze = false;
+        }
+        return;
+    }
 
     // Host-relative target and error
     Vector3D target = ComputeTarget();


### PR DESCRIPTION
## Summary
- Add `_kamikaze` flag and command handler to enable a suicide run toward the host
- Drive thrusters fully toward the host, align gyros, and detonate warheads on proximity or sensor trigger
- Clear overrides and reset kamikaze mode when detonation occurs or telemetry is lost

## Testing
- No tests were executed

------
https://chatgpt.com/codex/tasks/task_e_689fe6bdc930832d85486103b9a1b3d5