### PR TITLE
Add kamikaze-on-empty mode and antenna resupply tag for satellites

### DIFF
--- a/DONTREADME.md
+++ b/DONTREADME.md
@@ -4,3 +4,4 @@ Run these from the host Programmable Block terminal or via timer blocks.
 
 * `boom` – broadcasts `CMD|DETONATE|` causing satellites to immediately detonate.
 * `kamikaze` – broadcasts `CMD|KAMIKAZE|` ordering satellites to dive toward the host and detonate when within ~25 m.
+* `kamikazeempty on/off` – broadcasts `CMD|AMMO_KAMIKAZE|ON/OFF` to toggle kamikaze-on-empty mode. When enabled, satellites without ammo seek the nearest hostile grid and explode on impact; otherwise, they rename their antenna to request resupply.


### PR DESCRIPTION
## Summary
- Monitor satellite ammo and either mark antenna names for resupply or initiate kamikaze behavior when empty
- Allow host command `kamikazeempty on/off` to toggle kamikaze-on-empty
- Document `kamikazeempty on/off` command
- Only satellites execute ammo monitoring logic
- When kamikaze-on-empty is enabled, ammo-starved satellites keep searching for hostiles and switch to kamikaze if one appears

## Testing
- Tests skipped per user instruction

------
https://chatgpt.com/codex/tasks/task_e_68a03778db08832d8683da01fce214e8