### PR TITLE
Add configurable ammo depletion response for satellites

### DIFF
--- a/DONTREADME.md
+++ b/DONTREADME.md
@@ -3,6 +3,8 @@
 Run these from the host Programmable Block terminal or via timer blocks.
 
 * `boom` – broadcasts `CMD|DETONATE|` causing satellites to immediately detonate.
-* `kamikaze` – broadcasts `CMD|KAMIKAZE|` ordering satellites to dive toward the host and detonate when within ~25 m.
+* `kamikaze` – broadcasts `CMD|KAMIKAZE|` ordering satellites to dive toward their current target and detonate when within ~25 m.
 * `ceasefire` – broadcasts `CMD|CEASEFIRE|` disabling satellite weapons until rearmed.
 * `rearm` – broadcasts `CMD|REARM|` allowing satellites to fire again.
+* `kamikazeempty` – broadcasts `CMD|KAMEMPTY|1|` so satellites ram the nearest hostile grid once out of ammo.
+* `resupply` – broadcasts `CMD|KAMEMPTY|0|` restoring the default behaviour of signaling for resupply.


### PR DESCRIPTION
## Summary
- satellites monitor weapon ammo and rename their antenna HUD when empty
- host can toggle kamikaze-on-empty or resupply signaling via new commands
- kamikaze logic now targets hostile grids instead of the host

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a03ec90f8c832d9c09d8f9396e2e65