### PR TITLE
Add jump drive sync command for swarm

### DIFF
--- a/DONTREADME.md
+++ b/DONTREADME.md
@@ -6,3 +6,4 @@ Run these from the host Programmable Block terminal or via timer blocks.
 * `kamikaze` – broadcasts `CMD|KAMIKAZE|` ordering satellites to dive toward the host and detonate when within ~25 m.
 * `ceasefire` – broadcasts `CMD|CEASEFIRE|` disabling satellite weapons until rearmed.
 * `rearm` – broadcasts `CMD|REARM|` allowing satellites to fire again.
+* `jump` – broadcasts `CMD|JUMP|x|y|z|` with the host's jump target; satellites jump to this location shortly after.


### PR DESCRIPTION
## Summary
- broadcast host jump drive destination to satellites via `jump` command
- satellites delay, then jump to broadcasted location
- document new `jump` command

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a0439d26b0832da9d3911b74507b85