### PR TITLE
Add telemetry fail-safe detonation

### DIFF
--- a/DONTREADME.md
+++ b/DONTREADME.md
@@ -6,3 +6,7 @@ Run these from the host Programmable Block terminal or via timer blocks.
 * `kamikaze` – broadcasts `CMD|KAMIKAZE|` ordering satellites to dive toward the host and detonate when within ~25 m.
 * `ceasefire` – broadcasts `CMD|CEASEFIRE|` disabling satellite weapons until rearmed.
 * `rearm` – broadcasts `CMD|REARM|` allowing satellites to fire again.
+
+### Failsafe
+
+Satellites without any jump drives will automatically arm and detonate their warheads if host telemetry has been absent for more than 12 hours (but less than roughly 28 hours).

--- a/Swarm.cs
+++ b/Swarm.cs
@@ -59,6 +59,7 @@ readonly System.Collections.Generic.List<IMyGyro> _gyros = new System.Collection
 readonly System.Collections.Generic.List<IMyThrust> _thrusters = new System.Collections.Generic.List<IMyThrust>(64);
 readonly System.Collections.Generic.List<IMySensorBlock> _sensors = new System.Collections.Generic.List<IMySensorBlock>(8);
 readonly System.Collections.Generic.List<IMyWarhead> _warheads = new System.Collections.Generic.List<IMyWarhead>(8);
+readonly System.Collections.Generic.List<IMyJumpDrive> _jumpDrives = new System.Collections.Generic.List<IMyJumpDrive>(4);
 readonly System.Collections.Generic.List<IMyTerminalBlock> _weapons = new System.Collections.Generic.List<IMyTerminalBlock>(32);
 IMyTerminalBlock _trackingTurret;
 
@@ -250,6 +251,7 @@ void DiscoverBlocks()
     _thrusters.Clear();
     _sensors.Clear();
     _warheads.Clear();
+    _jumpDrives.Clear();
     _weapons.Clear();
     _trackingTurret = null;
     _axisX.Reset(); _axisY.Reset(); _axisZ.Reset();
@@ -277,6 +279,9 @@ void DiscoverBlocks()
 
         var t = b as IMyThrust;
         if (t != null) { _thrusters.Add(t); continue; }
+
+        var jd = b as IMyJumpDrive;
+        if (jd != null) { _jumpDrives.Add(jd); continue; }
 
         var w = b as IMyWarhead;
         if (w != null) { _warheads.Add(w); continue; }
@@ -447,6 +452,29 @@ public void Main(string argument, UpdateType updateSource)
     if (dt <= 0) dt = 1.0/6.0; // defensive on first tick (~Update10)
     _timeSinceTelemetry += dt;
     _tick++;
+
+    if (_role == Role.Satellite &&
+        _timeSinceTelemetry > 43200.0 && _timeSinceTelemetry < 100000.0)
+    {
+        bool hasJump = false;
+        for (int i=0; i<_jumpDrives.Count; i++)
+        {
+            var jd = _jumpDrives[i];
+            if (jd != null && jd.IsWorking) { hasJump = true; break; }
+        }
+        if (!hasJump)
+        {
+            for (int i=0; i<_warheads.Count; i++)
+            {
+                var w = _warheads[i];
+                if (w != null)
+                {
+                    w.IsArmed = true;
+                    w.Detonate();
+                }
+            }
+        }
+    }
 
     if (_friendListener != null)
     {


### PR DESCRIPTION
## Summary
- Track jump drives on satellites
- Auto-detonate satellites without jump drives if telemetry missing for over 12 hours
- Document telemetry-based failsafe

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a15728b5f4832d883bbf8395d947e8