### PR TITLE
Allow configuring weapon target subsystem

### DIFF
--- a/HostCustomData.ini
+++ b/HostCustomData.ini
@@ -9,7 +9,11 @@ ShellCount=3
 PointsPerShell=24
 ShellSpacing=300
 BaseRadius=2000
- 
+
+[Weapons]
+TargetSubsystem=Any
+; Options: Any, Offensive, Utility, Thrust, Power, Production, Jumping, Communication, Steering, Armor, Structure
+
 [Avoidance]
 HostRadius=0
 HostBuffer=22

--- a/SatelliteCustomData.ini
+++ b/SatelliteCustomData.ini
@@ -16,6 +16,10 @@ AlignToHost=true
 AlignKp=2.0
 AlignDeadzoneDeg=3
 ParkingFace=Forward
+
+[Weapons]
+TargetSubsystem=Any
+; Options: Any, Offensive, Utility, Thrust, Power, Production, Jumping, Communication, Steering, Armor, Structure
 [Avoidance]
 HostRadius=0
 HostBuffer=22

--- a/Swarm.cs
+++ b/Swarm.cs
@@ -53,6 +53,7 @@ int _index = -1; // satellite index (global)
 bool _debug = false;
 bool _kamikaze = false; // dive into target and detonate
 bool _weaponsEnabled = true; // allow weapon firing
+string _weaponSubsystem = "Any"; // WeaponCore subsystem targeting
 
 // cached blocks
 IMyShipController _controller;
@@ -194,6 +195,8 @@ void ParseIni()
     _controllerName = _ini.Get("Blocks","MainControllerName").ToString(_controllerName);
     _refForward     = _ini.Get("Blocks","ReferenceForward").ToString(_refForward);
     _refUp          = _ini.Get("Blocks","ReferenceUp").ToString(_refUp);
+
+    _weaponSubsystem = _ini.Get("Weapons","TargetSubsystem").ToString(_weaponSubsystem);
 
     // alignment options
     _alignToHost = _ini.Get("Control","AlignToHost").ToBoolean(_alignToHost);
@@ -372,6 +375,8 @@ void DiscoverBlocks()
         }
     }
 
+    ApplyWeaponTargeting();
+
     if (_useSensors)
     {
         _sensorFallback = (_sensors.Count == 0);
@@ -384,6 +389,16 @@ void DiscoverBlocks()
     else
     {
         _sensorFallback = false;
+    }
+}
+
+void ApplyWeaponTargeting()
+{
+    for (int i=0; i<_weapons.Count; i++)
+    {
+        var w = _weapons[i];
+        if (w.GetProperty("WC_TargetSubSystem") != null)
+            w.SetValue<string>("WC_TargetSubSystem", _weaponSubsystem);
     }
 }
 


### PR DESCRIPTION
## Summary
- allow satellites to specify WeaponCore subsystem targets via `[Weapons] TargetSubsystem`
- apply configured subsystem to all discovered weapons

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a260bc86c8832db59ed739272f66d2