### PR TITLE
Remove automatic shield disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## DragonSwarm
 
-An autonomous, host-and-swarm program running from a single script. Satellites fall into designated orbit slots, arranged in concentric shells. Satellites now conserve power by disabling shields when no hostile grid is within 50 km and by favoring lighter weapons against small targets.
+An autonomous, host-and-swarm program running from a single script. Satellites fall into designated orbit slots, arranged in concentric shells. Satellites favor lighter weapons against small targets.
 Drop the respective .ini files into the custom data field, and recompile.
 Very customizable., just edit the .inis
 

--- a/Swarm.cs
+++ b/Swarm.cs
@@ -54,7 +54,6 @@ bool _debug = false;
 bool _kamikaze = false; // dive into target and detonate
 bool _weaponsEnabled = true; // allow weapon firing
 string _weaponSubsystem = "Any"; // WeaponCore subsystem targeting
-double _shieldDisableRange = 50000.0; // meters: shields off beyond this enemy distance
 
 // cached blocks
 IMyShipController _controller;
@@ -638,12 +637,12 @@ void WeaponStep()
     if (!_weaponsEnabled)
     {
         CeaseFire();
-        UpdateShields(false);
+        UpdateShields();
         return;
     }
     if (_trackingTurret == null || _weapons.Count == 0 || _controller == null)
     {
-        UpdateShields(false);
+        UpdateShields();
         return;
     }
     long targetId;
@@ -652,9 +651,8 @@ void WeaponStep()
     bool hasTarget = TryGetTarget(out targetId, out targetPos, out targetSmall);
     double targetDist = hasTarget ? Vector3D.Distance(targetPos, _trackingTurret.GetPosition()) : double.MaxValue;
 
-    bool enemyNearby = hasTarget && targetDist <= _shieldDisableRange;
-    UpdateShields(enemyNearby);
-    if (enemyNearby && targetDist <= 12000.0)
+    UpdateShields();
+    if (hasTarget && targetDist <= 12000.0)
     {
         ApplyGyros(targetPos - _controller.GetPosition());
         FireWeapons(targetId, targetPos, targetSmall);
@@ -710,19 +708,12 @@ void CeaseFire()
     }
 }
 
-void UpdateShields(bool enemyNearby)
+void UpdateShields()
 {
     for (int i=0; i<_shields.Count; i++)
     {
         var s = _shields[i];
-        if (enemyNearby)
-        {
-            if (!s.Enabled) s.Enabled = true;
-        }
-        else
-        {
-            if (s.Enabled) s.Enabled = false;
-        }
+        if (!s.Enabled) s.Enabled = true;
     }
 }
 


### PR DESCRIPTION
## Summary
- keep shields active at all times by removing range-based shutdown logic
- clarify documentation to drop mention of shield power savings

## Testing
- `dotnet test` *(skipped: tests are not run for this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a3da95c470832d95143acf3eb2fd23