### PR TITLE
Reset shield drop on shield state and enemy flag

### DIFF
--- a/Swarm.cs
+++ b/Swarm.cs
@@ -841,15 +841,13 @@ void UpdateShields()
     else
     {
         _noEnemyTime += _dt;
-        if (_enemyInRange && _noEnemyTime >= 10.0)
+        _enemyInRange = false;
+        if (_shieldRaised && _noEnemyTime >= 10.0)
         {
             bool changed = false;
-            if (_shieldRaised)
-            {
-                _shieldController.ApplyAction("DS-C_ToggleShield_Off");
-                _shieldRaised = false;
-                changed = true;
-            }
+            _shieldController.ApplyAction("DS-C_ToggleShield_Off");
+            _shieldRaised = false;
+            changed = true;
             if (_shuntFocus != FaceSide.MatchHost)
             {
                 ApplyShuntConfig(FaceSide.MatchHost);
@@ -863,7 +861,6 @@ void UpdateShields()
                 _fortify = false;
                 changed = true;
             }
-            _enemyInRange = false;
             if (changed) _shieldCooldown = 2.0;
         }
     }


### PR DESCRIPTION
## Summary
- Drop shields only after 10 seconds without targets when shields are raised
- Clear `_enemyInRange` when no enemies are detected to allow future detections

## Testing
- ⚠️ No tests run: Space Engineers script only runs in-game

------
https://chatgpt.com/codex/tasks/task_e_68c7695f7958832d857eb106c523b528