### PR TITLE
Add standalone enemy targeting script with intercept prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ with at most four programmable blocks:
 2. **SwarmSatellite.cs** – runs on satellites or missiles.  Each instance
    listens for host telemetry, keeps to its assigned Fibonacci-sphere slot and
    executes host commands.
-3. **(Optional) additional PBs** can extend behaviour (weapon logic, dedicated
+3. **SwarmTarget.cs** – shares enemy contact data across the swarm and offers
+   intercept prediction based on target velocity.
+4. **(Optional) additional PBs** can extend behaviour (weapon logic, dedicated
    missile profiles) but the core system functions with only Host + Satellites.
 
 Shared logic lives in `SwarmCore.cs` and `SwarmIGC.cs`.  These files contain the

--- a/SwarmCore.cs
+++ b/SwarmCore.cs
@@ -34,4 +34,38 @@ static class SwarmCore
             return _p * error + _d * derivative;
         }
     }
+
+    // Predict intercept point for a moving target given projectile speed
+    public static VRageMath.Vector3D PredictIntercept(
+        VRageMath.Vector3D shooterPos,
+        VRageMath.Vector3D shooterVel,
+        VRageMath.Vector3D targetPos,
+        VRageMath.Vector3D targetVel,
+        double projectileSpeed)
+    {
+        VRageMath.Vector3D relPos = targetPos - shooterPos;
+        VRageMath.Vector3D relVel = targetVel - shooterVel;
+
+        double a = relVel.LengthSquared() - projectileSpeed * projectileSpeed;
+        double b = 2.0 * VRageMath.Vector3D.Dot(relVel, relPos);
+        double c = relPos.LengthSquared();
+        double t;
+
+        if (System.Math.Abs(a) < 1e-6)
+            t = -c / b;
+        else
+        {
+            double det = b * b - 4.0 * a * c;
+            if (det < 0)
+                return targetPos;
+            double sqrt = System.Math.Sqrt(det);
+            double t1 = (-b + sqrt) / (2.0 * a);
+            double t2 = (-b - sqrt) / (2.0 * a);
+            t = System.Math.Max(t1, t2);
+        }
+
+        if (t < 0)
+            t = 0;
+        return targetPos + relVel * t;
+    }
 }

--- a/SwarmTarget.cs
+++ b/SwarmTarget.cs
@@ -1,0 +1,133 @@
+// DragonSwarm Targeting module
+// Shares enemy contact data and provides intercept predictions
+
+IMyBroadcastListener _listener;
+IMyCameraBlock _lidar;
+
+long _targetId;
+VRageMath.Vector3D _targetPos;
+VRageMath.Vector3D _targetVel;
+int _lostTicks;
+const double LIDAR_RANGE = 4000.0; // meters
+const int CLEAR_TICKS = 5;          // ticks before forgetting target
+
+public Program()
+{
+    _listener = IGC.RegisterBroadcastListener(SwarmIGC.CHANNEL);
+    _listener.SetMessageCallback("IGC");
+
+    var cams = new System.Collections.Generic.List<IMyCameraBlock>();
+    GridTerminalSystem.GetBlocksOfType(cams);
+    if (cams.Count > 0)
+    {
+        _lidar = cams[0];
+        _lidar.EnableRaycast = true;
+    }
+
+    Runtime.UpdateFrequency = UpdateFrequency.Update10;
+}
+
+public void Main(string argument, UpdateType updateSource)
+{
+    if ((updateSource & UpdateType.IGC) != 0)
+        ProcessMessages();
+    if ((updateSource & UpdateType.Update10) != 0)
+        UpdateTarget();
+}
+
+void ProcessMessages()
+{
+    while (_listener.HasPendingMessage)
+    {
+        MyIGCMessage raw = _listener.AcceptMessage();
+        SwarmIGC.Message msg = new SwarmIGC.Message();
+        if (!SwarmIGC.TryParse(raw, ref msg))
+            continue;
+        if (msg.Command == "TARGET")
+        {
+            string[] parts = msg.Data.Split(';');
+            if (parts.Length == 3)
+            {
+                long id;
+                if (long.TryParse(parts[0], out id))
+                {
+                    _targetId = id;
+                    _targetPos = ParseVector(parts[1]);
+                    _targetVel = ParseVector(parts[2]);
+                    _lostTicks = 0;
+                }
+            }
+        }
+        else if (msg.Command == "CLEAR")
+        {
+            if (_targetId != 0 && (msg.Data == _targetId.ToString() || msg.Data.Length == 0))
+                ClearTarget();
+        }
+    }
+}
+
+void UpdateTarget()
+{
+    bool detected = false;
+    if (_lidar != null && _lidar.CanScan(LIDAR_RANGE))
+    {
+        MyDetectedEntityInfo info = _lidar.Raycast(LIDAR_RANGE);
+        if (!info.IsEmpty() && info.Relationship == MyRelationsBetweenPlayerAndBlock.Enemies)
+        {
+            _targetId = info.EntityId;
+            _targetPos = info.Position;
+            _targetVel = info.Velocity;
+            _lostTicks = 0;
+            detected = true;
+        }
+    }
+
+    if (detected)
+    {
+        BroadcastTarget();
+    }
+    else if (_targetId != 0)
+    {
+        _lostTicks++;
+        if (_lostTicks > CLEAR_TICKS)
+            ClearTarget();
+    }
+}
+
+void BroadcastTarget()
+{
+    string data = _targetId.ToString() + ";" + FormatVector(_targetPos) + ";" + FormatVector(_targetVel);
+    SwarmIGC.Send(IGC, new SwarmIGC.Message { Sender = Me.CubeGrid.EntityId, Command = "TARGET", Data = data });
+}
+
+void ClearTarget()
+{
+    SwarmIGC.Send(IGC, new SwarmIGC.Message { Sender = Me.CubeGrid.EntityId, Command = "CLEAR", Data = _targetId.ToString() });
+    _targetId = 0;
+    _targetPos = new VRageMath.Vector3D();
+    _targetVel = new VRageMath.Vector3D();
+    _lostTicks = 0;
+}
+
+// Obtain predicted intercept point for a projectile
+VRageMath.Vector3D GetIntercept(VRageMath.Vector3D shooterPos, VRageMath.Vector3D shooterVel, double projectileSpeed)
+{
+    if (_targetId == 0)
+        return shooterPos;
+    return SwarmCore.PredictIntercept(shooterPos, shooterVel, _targetPos, _targetVel, projectileSpeed);
+}
+
+static VRageMath.Vector3D ParseVector(string s)
+{
+    string[] a = s.Split(',');
+    double x = 0, y = 0, z = 0;
+    if (a.Length > 0) double.TryParse(a[0], out x);
+    if (a.Length > 1) double.TryParse(a[1], out y);
+    if (a.Length > 2) double.TryParse(a[2], out z);
+    return new VRageMath.Vector3D(x, y, z);
+}
+
+static string FormatVector(VRageMath.Vector3D v)
+{
+    return v.X.ToString("0.##") + "," + v.Y.ToString("0.##") + "," + v.Z.ToString("0.##");
+}


### PR DESCRIPTION
## Summary
- Add SwarmTarget script that shares enemy data via IGC and clears stale contacts
- Integrate Lidar scanning with antenna fallback for target acquisition
- Provide intercept prediction utility in SwarmCore and update docs

## Testing
- No tests were run


------
https://chatgpt.com/codex/tasks/task_e_68c7885009e4832da670d7c29686656b